### PR TITLE
link: builder

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,14 @@
 
 
 [[projects]]
+  digest = "1:a2c1d0e43bd3baaa071d1b9ed72c27d78169b2b269f71c105ac4ba34b1be4a39"
+  name = "github.com/davecgh/go-spew"
+  packages = ["spew"]
+  pruneopts = "UT"
+  revision = "346938d642f2ec3594ed81d874461961cd0faa76"
+  version = "v1.1.0"
+
+[[projects]]
   digest = "1:15042ad3498153684d09f393bbaec6b216c8eec6d61f63dff711de7d64ed8861"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
@@ -9,9 +17,41 @@
   revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
   version = "v1.1.0"
 
+[[projects]]
+  digest = "1:40e195917a951a8bf867cd05de2a46aaf1806c50cf92eebf4c16f78cd196f747"
+  name = "github.com/pkg/errors"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
+  version = "v0.8.0"
+
+[[projects]]
+  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
+  name = "github.com/pmezard/go-difflib"
+  packages = ["difflib"]
+  pruneopts = "UT"
+  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
+  version = "v1.0.0"
+
+[[projects]]
+  digest = "1:c40d65817cdd41fac9aa7af8bed56927bb2d6d47e4fea566a74880f5c2b1c41e"
+  name = "github.com/stretchr/testify"
+  packages = [
+    "assert",
+    "require",
+  ]
+  pruneopts = "UT"
+  revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
+  version = "v1.2.2"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  input-imports = ["github.com/golang/protobuf/proto"]
+  input-imports = [
+    "github.com/golang/protobuf/proto",
+    "github.com/pkg/errors",
+    "github.com/stretchr/testify/assert",
+    "github.com/stretchr/testify/require",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -2,6 +2,10 @@
   name = "github.com/golang/protobuf"
   version = "1.1.0"
 
+[[constraint]]
+  name = "github.com/stretchr/testify"
+  version = "1.2.2"
+
 [prune]
   go-tests = true
   unused-packages = true

--- a/const.go
+++ b/const.go
@@ -1,0 +1,21 @@
+// Copyright 2017-2018 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainscript
+
+const (
+	// ClientID allows segment receivers to figure out how the segment was
+	// encoded and can be decoded.
+	ClientID = "github.com/stratumn/go-chainscript"
+)

--- a/link.go
+++ b/link.go
@@ -1,0 +1,54 @@
+// Copyright 2017-2018 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainscript
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+
+	"github.com/golang/protobuf/proto"
+)
+
+// Hash serializes the link using protobuf and computes a SHA256 hash of the
+// resulting bytes.
+func (l *Link) Hash() ([]byte, error) {
+	b, err := proto.Marshal(l)
+	if err != nil {
+		return nil, err
+	}
+
+	lh := sha256.Sum256(b)
+	return lh[:], nil
+}
+
+// HashString returns the hex-encoded link hash.
+func (l *Link) HashString() (string, error) {
+	lh, err := l.Hash()
+	if err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(lh), nil
+}
+
+// PrevLinkHash returns the link's parent hash.
+// If the link doesn't have a parent, it returns nil.
+func (l *Link) PrevLinkHash() []byte {
+	if l.Meta == nil {
+		return nil
+	}
+
+	return l.Meta.PrevLinkHash
+}

--- a/link_test.go
+++ b/link_test.go
@@ -1,0 +1,54 @@
+// Copyright 2017-2018 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainscript_test
+
+import (
+	"testing"
+
+	"github.com/stratumn/go-chainscript"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLink_Hash(t *testing.T) {
+	l1, _ := chainscript.NewLinkBuilder("p1", "m1").Build()
+	l2, _ := chainscript.NewLinkBuilder("p1", "m1").Build()
+	l3, _ := chainscript.NewLinkBuilder("p2", "m42").Build()
+
+	h1, err := l1.Hash()
+	require.NoError(t, err)
+	assert.Len(t, h1, 32)
+
+	h2, err := l2.Hash()
+	require.NoError(t, err)
+	assert.Equal(t, h1, h2)
+
+	h3, err := l3.Hash()
+	require.NoError(t, err)
+	assert.NotEqual(t, h1, h3)
+}
+
+func TestLink_HashString(t *testing.T) {
+	l, _ := chainscript.NewLinkBuilder("p1", "m1").Build()
+
+	h, err := l.HashString()
+	require.NoError(t, err)
+	assert.NotEmpty(t, h)
+}
+
+func TestLink_PrevLinkHash(t *testing.T) {
+	l1, _ := chainscript.NewLinkBuilder("p1", "m1").Build()
+	assert.Nil(t, l1.PrevLinkHash())
+}

--- a/linkbuilder.go
+++ b/linkbuilder.go
@@ -23,8 +23,9 @@ const (
 
 // Link errors.
 var (
-	ErrMissingProcess = errors.New("link process is missing")
-	ErrMissingMapID   = errors.New("link map id is missing")
+	ErrMissingProcess  = errors.New("link process is missing")
+	ErrMissingMapID    = errors.New("link map id is missing")
+	ErrInvalidPriority = errors.New("priority needs to be positive")
 )
 
 // LinkBuilder makes it easy to create links that adhere to the ChainScript
@@ -60,6 +61,44 @@ func NewLinkBuilder(process string, mapID string) *LinkBuilder {
 		},
 		err: err,
 	}
+}
+
+// WithAction sets the link's action.
+// The action is what caused the link to be created.
+func (b *LinkBuilder) WithAction(action string) *LinkBuilder {
+	b.link.Meta.Action = action
+	return b
+}
+
+// WithPriority sets the link's priority.
+func (b *LinkBuilder) WithPriority(priority float64) *LinkBuilder {
+	if priority <= 0 {
+		b.err = ErrInvalidPriority
+		return b
+	}
+
+	b.link.Meta.Priority = priority
+	return b
+}
+
+// WithProcessState sets the state of the process.
+// If your process can be represented as a state machine and the current link
+// changes the state machine, it allows easy tracking of the process evolution.
+func (b *LinkBuilder) WithProcessState(state string) *LinkBuilder {
+	b.link.Meta.Process.State = state
+	return b
+}
+
+// WithStep sets the specific process step represented by the link.
+func (b *LinkBuilder) WithStep(step string) *LinkBuilder {
+	b.link.Meta.Step = step
+	return b
+}
+
+// WithTags adds some tags to the link.
+func (b *LinkBuilder) WithTags(tags ...string) *LinkBuilder {
+	b.link.Meta.Tags = append(b.link.Meta.Tags, tags...)
+	return b
 }
 
 // Build returns the corresponding link or an error.

--- a/linkbuilder.go
+++ b/linkbuilder.go
@@ -19,6 +19,10 @@ import "github.com/pkg/errors"
 const (
 	// LinkVersion is the current version of the link encoding.
 	LinkVersion = "1.0.0"
+
+	// LinkHashSize is the size of a link hash. In the current version we use
+	// SHA-256 so this should be 32.
+	LinkHashSize = 32
 )
 
 // Link errors.
@@ -26,6 +30,7 @@ var (
 	ErrMissingProcess  = errors.New("link process is missing")
 	ErrMissingMapID    = errors.New("link map id is missing")
 	ErrInvalidPriority = errors.New("priority needs to be positive")
+	ErrInvalidLinkHash = errors.New("invalid link hash")
 )
 
 // LinkBuilder makes it easy to create links that adhere to the ChainScript
@@ -67,6 +72,17 @@ func NewLinkBuilder(process string, mapID string) *LinkBuilder {
 // The action is what caused the link to be created.
 func (b *LinkBuilder) WithAction(action string) *LinkBuilder {
 	b.link.Meta.Action = action
+	return b
+}
+
+// WithParent sets the link's parent, referenced by its hash.
+func (b *LinkBuilder) WithParent(linkHash []byte) *LinkBuilder {
+	if len(linkHash) != LinkHashSize {
+		b.err = ErrInvalidLinkHash
+		return b
+	}
+
+	b.link.Meta.PrevLinkHash = linkHash
 	return b
 }
 

--- a/linkbuilder.go
+++ b/linkbuilder.go
@@ -113,7 +113,14 @@ func (b *LinkBuilder) WithStep(step string) *LinkBuilder {
 
 // WithTags adds some tags to the link.
 func (b *LinkBuilder) WithTags(tags ...string) *LinkBuilder {
-	b.link.Meta.Tags = append(b.link.Meta.Tags, tags...)
+	for _, tag := range tags {
+		if len(tag) == 0 {
+			continue
+		}
+
+		b.link.Meta.Tags = append(b.link.Meta.Tags, tag)
+	}
+
 	return b
 }
 

--- a/linkbuilder.go
+++ b/linkbuilder.go
@@ -1,0 +1,72 @@
+// Copyright 2017-2018 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainscript
+
+import "github.com/pkg/errors"
+
+const (
+	// LinkVersion is the current version of the link encoding.
+	LinkVersion = "1.0.0"
+)
+
+// Link errors.
+var (
+	ErrMissingProcess = errors.New("link process is missing")
+	ErrMissingMapID   = errors.New("link map id is missing")
+)
+
+// LinkBuilder makes it easy to create links that adhere to the ChainScript
+// spec.
+// It provides valid default values for required fields and allows the user
+// to set fields to valid values.
+type LinkBuilder struct {
+	link *Link
+	err  error
+}
+
+// NewLinkBuilder creates a new link builder.
+func NewLinkBuilder(process string, mapID string) *LinkBuilder {
+	var err error
+	if len(process) == 0 {
+		err = ErrMissingProcess
+	}
+
+	if len(mapID) == 0 {
+		err = ErrMissingMapID
+	}
+
+	return &LinkBuilder{
+		link: &Link{
+			Version: LinkVersion,
+			Meta: &LinkMeta{
+				ClientId: ClientID,
+				Process: &Process{
+					Name: process,
+				},
+				MapId: mapID,
+			},
+		},
+		err: err,
+	}
+}
+
+// Build returns the corresponding link or an error.
+func (b *LinkBuilder) Build() (*Link, error) {
+	if b.err != nil {
+		return nil, b.err
+	}
+
+	return b.link, nil
+}

--- a/linkbuilder_test.go
+++ b/linkbuilder_test.go
@@ -26,6 +26,12 @@ func TestLinkBuilder(t *testing.T) {
 	process := "test_process"
 	mapID := "test_map_1"
 
+	testLink, err := chainscript.NewLinkBuilder(process, mapID).Build()
+	require.NoError(t, err)
+
+	testLinkHash, err := testLink.Hash()
+	require.NoError(t, err)
+
 	testCases := []struct {
 		name     string
 		builder  *chainscript.LinkBuilder
@@ -96,6 +102,18 @@ func TestLinkBuilder(t *testing.T) {
 			assert.ElementsMatch(t, []string{"tag1", "tag2", "tag3"}, l.Meta.Tags)
 		},
 		nil,
+	}, {
+		"parent",
+		chainscript.NewLinkBuilder(process, mapID).WithParent(testLinkHash),
+		func(t *testing.T, l *chainscript.Link) {
+			assert.Equal(t, testLinkHash, l.PrevLinkHash())
+		},
+		nil,
+	}, {
+		"invalid parent",
+		chainscript.NewLinkBuilder(process, mapID).WithParent([]byte{42, 24, 63}),
+		nil,
+		chainscript.ErrInvalidLinkHash,
 	}}
 
 	for _, tt := range testCases {

--- a/linkbuilder_test.go
+++ b/linkbuilder_test.go
@@ -49,6 +49,13 @@ func TestLinkBuilder(t *testing.T) {
 		},
 		nil,
 	}, {
+		"client ID",
+		chainscript.NewLinkBuilder(process, mapID),
+		func(t *testing.T, l *chainscript.Link) {
+			assert.Equal(t, chainscript.ClientID, l.Meta.ClientId)
+		},
+		nil,
+	}, {
 		"action",
 		chainscript.NewLinkBuilder(process, mapID).WithAction("receive-document"),
 		func(t *testing.T, l *chainscript.Link) {

--- a/linkbuilder_test.go
+++ b/linkbuilder_test.go
@@ -114,6 +114,29 @@ func TestLinkBuilder(t *testing.T) {
 		chainscript.NewLinkBuilder(process, mapID).WithParent([]byte{42, 24, 63}),
 		nil,
 		chainscript.ErrInvalidLinkHash,
+	}, {
+		"refs",
+		chainscript.NewLinkBuilder(process, mapID).WithRefs(
+			&chainscript.LinkReference{Process: process, PrevLinkHash: testLinkHash},
+			&chainscript.LinkReference{Process: process, PrevLinkHash: testLinkHash},
+			&chainscript.LinkReference{Process: process, PrevLinkHash: make([]byte, 32)},
+		),
+		func(t *testing.T, l *chainscript.Link) {
+			expected := []*chainscript.LinkReference{
+				&chainscript.LinkReference{Process: process, PrevLinkHash: testLinkHash},
+				&chainscript.LinkReference{Process: process, PrevLinkHash: make([]byte, 32)},
+			}
+			assert.ElementsMatch(t, expected, l.Meta.Refs)
+		},
+		nil,
+	}, {
+		"invalid refs",
+		chainscript.NewLinkBuilder(process, mapID).WithRefs(
+			&chainscript.LinkReference{Process: "", PrevLinkHash: testLinkHash},
+			&chainscript.LinkReference{Process: process, PrevLinkHash: testLinkHash},
+		),
+		nil,
+		chainscript.ErrMissingProcess,
 	}}
 
 	for _, tt := range testCases {

--- a/linkbuilder_test.go
+++ b/linkbuilder_test.go
@@ -1,0 +1,44 @@
+// Copyright 2017-2018 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainscript_test
+
+import (
+	"testing"
+
+	"github.com/stratumn/go-chainscript"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLinkBuilder(t *testing.T) {
+	t.Run("missing process", func(t *testing.T) {
+		l, err := chainscript.NewLinkBuilder("", "mapID_123").Build()
+		assert.EqualError(t, err, chainscript.ErrMissingProcess.Error())
+		assert.Nil(t, l)
+	})
+
+	t.Run("missing map ID", func(t *testing.T) {
+		l, err := chainscript.NewLinkBuilder("process1", "").Build()
+		assert.EqualError(t, err, chainscript.ErrMissingMapID.Error())
+		assert.Nil(t, l)
+	})
+
+	t.Run("version", func(t *testing.T) {
+		l, err := chainscript.NewLinkBuilder("p1", "map1").Build()
+		require.NoError(t, err)
+		require.NotNil(t, l)
+		assert.Equal(t, chainscript.LinkVersion, l.Version)
+	})
+}

--- a/linkbuilder_test.go
+++ b/linkbuilder_test.go
@@ -96,7 +96,7 @@ func TestLinkBuilder(t *testing.T) {
 		nil,
 	}, {
 		"tags",
-		chainscript.NewLinkBuilder(process, mapID).WithTags("tag1", "tag2").WithTags("tag3"),
+		chainscript.NewLinkBuilder(process, mapID).WithTags("tag1", "tag2").WithTags("", "tag3"),
 		func(t *testing.T, l *chainscript.Link) {
 			assert.Len(t, l.Meta.Tags, 3)
 			assert.ElementsMatch(t, []string{"tag1", "tag2", "tag3"}, l.Meta.Tags)


### PR DESCRIPTION
A simple link builder to set and validate the link's meta fields.
Nothing fancy, this is quite boring code for now.

The only subtlety is related to hashing. The hash can now change easily so we're getting rid a Bytes32 (since we could choose to move to SHA3 or Blake2B at some point and it wouldn't be 32 bytes). When you reference a link after a version change, you will calculate its hash *at the current version* (and not use the hash of the previous version). This is a good thing because it means we're seamlessly upgrading the hash algorithm used.