### PR TITLE
link: set/get data/metadata and segment utilities

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -22,6 +22,7 @@ parsers:
 
 ignore:
   - "*.pb.go"
+  - "chainscripttest"
 
 comment:
   layout: "header, diff"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -13,7 +13,11 @@ coverage:
         target: 70
         threshold: 2
         base: auto
-    patch: yes
+    patch:
+      default:
+        target: 70
+        threshold: 2
+        base: auto
     changes: no
 
 parsers:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,10 +5,14 @@ codecov:
 coverage:
   precision: 2
   round: down
-  range: "70...100"
+  range: "65...90"
 
   status:
-    project: yes
+    project:
+      default:
+        target: 70
+        threshold: 2
+        base: auto
     patch: yes
     changes: no
 

--- a/chainscripttest/builder.go
+++ b/chainscripttest/builder.go
@@ -1,0 +1,206 @@
+// Copyright 2017-2018 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainscripttest
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/stratumn/go-chainscript"
+	"github.com/stretchr/testify/require"
+)
+
+// LinkBuilder allows building links easily in tests.
+type LinkBuilder struct {
+	t    *testing.T
+	Link *chainscript.Link
+}
+
+// NewLinkBuilder creates a new LinkBuilder.
+func NewLinkBuilder(t *testing.T) *LinkBuilder {
+	l, err := chainscript.NewLinkBuilder("process", "mapID").Build()
+	require.NoError(t, err)
+
+	return &LinkBuilder{Link: l}
+}
+
+// Branch uses the provided link as its parent and copies its mapID and process.
+func (lb *LinkBuilder) Branch(parent *chainscript.Link) *LinkBuilder {
+	lh, err := parent.Hash()
+	require.NoError(lb.t, err)
+
+	lb.Link.Meta.PrevLinkHash = lh
+	lb.Link.Meta.MapId = parent.Meta.MapId
+	lb.Link.Meta.Process = &chainscript.Process{
+		Name:  parent.Meta.Process.Name,
+		State: parent.Meta.Process.State,
+	}
+
+	return lb
+}
+
+// From clones the given link.
+func (lb *LinkBuilder) From(l *chainscript.Link) *LinkBuilder {
+	var err error
+	lb.Link, err = l.Clone()
+	require.NoError(lb.t, err)
+
+	return lb
+}
+
+// WithAction fills the link's action.
+func (lb *LinkBuilder) WithAction(action string) *LinkBuilder {
+	lb.Link.Meta.Action = action
+	return lb
+}
+
+// WithData fills the link's data.
+func (lb *LinkBuilder) WithData(data interface{}) *LinkBuilder {
+	err := lb.Link.SetData(data)
+	require.NoError(lb.t, err)
+
+	return lb
+}
+
+// WithInvalidFields makes the link invalid by setting some fields to invalid
+// values.
+func (lb *LinkBuilder) WithInvalidFields() *LinkBuilder {
+	lb.Link.Meta.Process = nil
+	lb.Link.Meta.MapId = ""
+	return lb
+}
+
+// WithMapID fills the link's mapID.
+func (lb *LinkBuilder) WithMapID(mapID string) *LinkBuilder {
+	lb.Link.Meta.MapId = mapID
+	return lb
+}
+
+// WithMetadata sets the link meta.Data field.
+func (lb *LinkBuilder) WithMetadata(metadata interface{}) *LinkBuilder {
+	err := lb.Link.SetMetadata(metadata)
+	require.NoError(lb.t, err)
+
+	return lb
+}
+
+// WithoutParent removes the link's parent (prevLinkHash).
+func (lb *LinkBuilder) WithoutParent() *LinkBuilder {
+	lb.Link.Meta.PrevLinkHash = nil
+	return lb
+}
+
+// WithParent fills the link's prevLinkHash with the given parent's hash.
+func (lb *LinkBuilder) WithParent(link *chainscript.Link) *LinkBuilder {
+	linkHash, err := link.Hash()
+	require.NoError(lb.t, err)
+
+	lb.Link.Meta.PrevLinkHash = linkHash
+	return lb
+}
+
+// WithParentHash fills the link's prevLinkHash.
+func (lb *LinkBuilder) WithParentHash(linkHash []byte) *LinkBuilder {
+	lb.Link.Meta.PrevLinkHash = linkHash
+	return lb
+}
+
+// WithPriority fills the link's priority.
+func (lb *LinkBuilder) WithPriority(priority float64) *LinkBuilder {
+	lb.Link.Meta.Priority = priority
+	return lb
+}
+
+// WithProcess fills the link's process.
+func (lb *LinkBuilder) WithProcess(process string) *LinkBuilder {
+	if lb.Link.Meta.Process == nil {
+		lb.Link.Meta.Process = &chainscript.Process{}
+	}
+
+	lb.Link.Meta.Process.Name = process
+	return lb
+}
+
+// WithProcessState fills the link's process state.
+func (lb *LinkBuilder) WithProcessState(state string) *LinkBuilder {
+	if lb.Link.Meta.Process == nil {
+		lb.Link.Meta.Process = &chainscript.Process{}
+	}
+
+	lb.Link.Meta.Process.State = state
+	return lb
+}
+
+// WithRandomData sets random data in most fields of the link.
+func (lb *LinkBuilder) WithRandomData() *LinkBuilder {
+	lb.Link.Data = RandomBytes(42)
+	lb.Link.Meta.Action = RandomString(12)
+	lb.Link.Meta.Data = RandomBytes(24)
+	lb.Link.Meta.MapId = RandomString(24)
+	lb.Link.Meta.PrevLinkHash = RandomHash()
+	lb.Link.Meta.Priority = rand.Float64()
+	lb.Link.Meta.Process = &chainscript.Process{
+		Name:  RandomString(24),
+		State: RandomString(24),
+	}
+	lb.Link.Meta.Step = RandomString(12)
+	lb.Link.Meta.Tags = []string{RandomString(12), RandomString(12)}
+
+	return lb
+}
+
+// WithRef adds a reference to the link.
+func (lb *LinkBuilder) WithRef(link *chainscript.Link) *LinkBuilder {
+	require.NotNil(lb.t, link.Meta.Process)
+
+	refHash, err := link.Hash()
+	require.NoError(lb.t, err)
+
+	lb.Link.Meta.Refs = append(lb.Link.Meta.Refs, &chainscript.LinkReference{
+		LinkHash: refHash,
+		Process:  link.Meta.Process.Name,
+	})
+
+	return lb
+}
+
+// WithStep fills the link's step.
+func (lb *LinkBuilder) WithStep(step string) *LinkBuilder {
+	lb.Link.Meta.Step = step
+	return lb
+}
+
+// WithTag adds a tag to the link.
+func (lb *LinkBuilder) WithTag(tag string) *LinkBuilder {
+	lb.Link.Meta.Tags = append(lb.Link.Meta.Tags, tag)
+	return lb
+}
+
+// WithTags replaces the link's tags.
+func (lb *LinkBuilder) WithTags(tags ...string) *LinkBuilder {
+	lb.Link.Meta.Tags = tags
+	return lb
+}
+
+// WithVersion sets the link's version.
+func (lb *LinkBuilder) WithVersion(version string) *LinkBuilder {
+	lb.Link.Version = version
+	return lb
+}
+
+// Build returns the underlying link.
+func (lb *LinkBuilder) Build() *chainscript.Link {
+	return lb.Link
+}

--- a/chainscripttest/random.go
+++ b/chainscripttest/random.go
@@ -1,0 +1,42 @@
+// Copyright 2017-2018 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainscripttest
+
+import (
+	"math/rand"
+)
+
+var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+// RandomBytes returns a random byte array of the specified length.
+func RandomBytes(n int) []byte {
+	b := make([]byte, n)
+	rand.Read(b)
+	return b
+}
+
+// RandomHash creates a random hash.
+func RandomHash() []byte {
+	return RandomBytes(32)
+}
+
+// RandomString generates a random string.
+func RandomString(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
+}

--- a/link.go
+++ b/link.go
@@ -60,9 +60,9 @@ func (l *Link) SetData(data interface{}) error {
 	return nil
 }
 
-// GetTypedData deserializes the link's data into the given object.
+// StructurizeData deserializes the link's data into the given object.
 // The provided argument should be a pointer to a struct.
-func (l *Link) GetTypedData(data interface{}) error {
+func (l *Link) StructurizeData(data interface{}) error {
 	switch l.Version {
 	case LinkVersion1_0_0:
 		return json.Unmarshal(l.Data, data)
@@ -88,9 +88,9 @@ func (l *Link) SetMetadata(metadata interface{}) error {
 	return nil
 }
 
-// GetTypedMetadata deserializes the link's metadata into the given object.
+// StructurizeMetadata deserializes the link's metadata into the given object.
 // The provided argument should be a pointer to a struct.
-func (l *Link) GetTypedMetadata(metadata interface{}) error {
+func (l *Link) StructurizeMetadata(metadata interface{}) error {
 	switch l.Version {
 	case LinkVersion1_0_0:
 		return json.Unmarshal(l.Meta.Data, metadata)
@@ -136,9 +136,9 @@ func (l *Link) PrevLinkHash() []byte {
 	return l.Meta.PrevLinkHash
 }
 
-// GetTagMap returns the tags as a map of string to empty structs (a set).
+// TagMap returns the tags as a map of string to empty structs (a set).
 // It makes it easier to test inclusion.
-func (l *Link) GetTagMap() map[string]struct{} {
+func (l *Link) TagMap() map[string]struct{} {
 	tags := make(map[string]struct{})
 	for _, v := range l.Meta.Tags {
 		tags[v] = struct{}{}

--- a/link.go
+++ b/link.go
@@ -43,6 +43,62 @@ var (
 // GetSegmentFunc is the function signature to retrieve a Segment.
 type GetSegmentFunc func(ctx context.Context, linkHash []byte) (*Segment, error)
 
+// SetData uses the given object as link's custom data.
+func (l *Link) SetData(data interface{}) error {
+	switch l.Version {
+	case LinkVersion1_0_0:
+		dataBytes, err := json.Marshal(data)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		l.Data = dataBytes
+	default:
+		return ErrUnknownLinkVersion
+	}
+
+	return nil
+}
+
+// GetTypedData deserializes the link's data into the given object.
+// The provided argument should be a pointer to a struct.
+func (l *Link) GetTypedData(data interface{}) error {
+	switch l.Version {
+	case LinkVersion1_0_0:
+		return json.Unmarshal(l.Data, data)
+	default:
+		return ErrUnknownLinkVersion
+	}
+}
+
+// SetMetadata uses the given object as link's custom metadata.
+func (l *Link) SetMetadata(metadata interface{}) error {
+	switch l.Version {
+	case LinkVersion1_0_0:
+		metadataBytes, err := json.Marshal(metadata)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		l.Meta.Data = metadataBytes
+	default:
+		return ErrUnknownLinkVersion
+	}
+
+	return nil
+}
+
+// GetTypedMetadata deserializes the link's metadata into the given object.
+// The provided argument should be a pointer to a struct.
+func (l *Link) GetTypedMetadata(metadata interface{}) error {
+	switch l.Version {
+	case LinkVersion1_0_0:
+		return json.Unmarshal(l.Meta.Data, metadata)
+	default:
+		return ErrUnknownLinkVersion
+	}
+}
+
 // Hash serializes the link and computes a hash of the resulting bytes.
 // The serialization and hashing algorithm used depend on the link version.
 func (l *Link) Hash() ([]byte, error) {

--- a/link_test.go
+++ b/link_test.go
@@ -32,7 +32,7 @@ func TestLink_Data(t *testing.T) {
 		assert.EqualError(t, err, chainscript.ErrUnknownLinkVersion.Error())
 
 		var data string
-		err = l.GetTypedData(data)
+		err = l.StructurizeData(data)
 		assert.EqualError(t, err, chainscript.ErrUnknownLinkVersion.Error())
 	})
 
@@ -49,7 +49,7 @@ func TestLink_Data(t *testing.T) {
 		require.NotNil(t, l.Data)
 
 		var data2 map[string]interface{}
-		err = l.GetTypedData(&data2)
+		err = l.StructurizeData(&data2)
 		require.NoError(t, err)
 		assert.Len(t, data2, 2)
 		assert.Equal(t, "spongebob", data2["user"])
@@ -67,7 +67,7 @@ func TestLink_Metadata(t *testing.T) {
 		assert.EqualError(t, err, chainscript.ErrUnknownLinkVersion.Error())
 
 		var metadata string
-		err = l.GetTypedMetadata(metadata)
+		err = l.StructurizeMetadata(metadata)
 		assert.EqualError(t, err, chainscript.ErrUnknownLinkVersion.Error())
 	})
 
@@ -80,7 +80,7 @@ func TestLink_Metadata(t *testing.T) {
 		require.NotNil(t, l.Meta.Data)
 
 		var metadata string
-		err = l.GetTypedMetadata(&metadata)
+		err = l.StructurizeMetadata(&metadata)
 		require.NoError(t, err)
 		assert.Equal(t, "spongebob rocks", metadata)
 	})
@@ -125,16 +125,16 @@ func TestLink_PrevLinkHash(t *testing.T) {
 	assert.Nil(t, l.PrevLinkHash())
 }
 
-func TestLink_GetTagMap(t *testing.T) {
+func TestLink_TagMap(t *testing.T) {
 	t.Run("empty tags", func(t *testing.T) {
 		l := chainscripttest.NewLinkBuilder(t).Build()
-		tags := l.GetTagMap()
+		tags := l.TagMap()
 		assert.Empty(t, tags)
 	})
 
 	t.Run("with tags", func(t *testing.T) {
 		l := chainscripttest.NewLinkBuilder(t).WithTags("t1", "t2").Build()
-		tags := l.GetTagMap()
+		tags := l.TagMap()
 		assert.Contains(t, tags, "t1")
 		assert.Contains(t, tags, "t2")
 		assert.NotContains(t, tags, "t3")

--- a/linkbuilder.go
+++ b/linkbuilder.go
@@ -17,7 +17,6 @@ package chainscript
 import (
 	"encoding/hex"
 
-	json "github.com/gibson042/canonicaljson-go"
 	"github.com/pkg/errors"
 )
 
@@ -76,25 +75,23 @@ func (b *LinkBuilder) WithAction(action string) *LinkBuilder {
 
 // WithData uses the given object as link's custom data.
 func (b *LinkBuilder) WithData(data interface{}) *LinkBuilder {
-	dataBytes, err := json.Marshal(data)
+	err := b.link.SetData(data)
 	if err != nil {
-		b.err = errors.WithStack(err)
+		b.err = err
 		return b
 	}
 
-	b.link.Data = dataBytes
 	return b
 }
 
 // WithMetadata uses the given object as link's custom metadata.
 func (b *LinkBuilder) WithMetadata(data interface{}) *LinkBuilder {
-	metadataBytes, err := json.Marshal(data)
+	err := b.link.SetMetadata(data)
 	if err != nil {
-		b.err = errors.WithStack(err)
+		b.err = err
 		return b
 	}
 
-	b.link.Meta.Data = metadataBytes
 	return b
 }
 

--- a/segment.go
+++ b/segment.go
@@ -27,13 +27,13 @@ var (
 	ErrLinkHashMismatch = errors.New("link hash from meta doesn't equal hashed link")
 )
 
-// GetLinkHash returns the link hash.
-func (s *Segment) GetLinkHash() []byte {
+// LinkHash returns the link hash.
+func (s *Segment) LinkHash() []byte {
 	return s.Meta.LinkHash
 }
 
-// GetLinkHashString returns the hex-encoded link hash.
-func (s *Segment) GetLinkHashString() string {
+// LinkHashString returns the hex-encoded link hash.
+func (s *Segment) LinkHashString() string {
 	return hex.EncodeToString(s.Meta.LinkHash)
 }
 

--- a/segment.go
+++ b/segment.go
@@ -1,0 +1,71 @@
+// Copyright 2017-2018 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainscript
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+
+	"github.com/pkg/errors"
+)
+
+// Segment errors.
+var (
+	ErrLinkHashMismatch = errors.New("link hash from meta doesn't equal hashed link")
+)
+
+// GetLinkHash returns the link hash.
+func (s *Segment) GetLinkHash() []byte {
+	return s.Meta.LinkHash
+}
+
+// GetLinkHashString returns the hex-encoded link hash.
+func (s *Segment) GetLinkHashString() string {
+	return hex.EncodeToString(s.Meta.LinkHash)
+}
+
+// SetLinkHash computes and sets the link hash.
+func (s *Segment) SetLinkHash() error {
+	linkHash, err := s.Link.Hash()
+	if err != nil {
+		return err
+	}
+
+	if s.Meta == nil {
+		s.Meta = &SegmentMeta{}
+	}
+
+	s.Meta.LinkHash = linkHash
+	return nil
+}
+
+// Validate checks for errors in a segment
+func (s *Segment) Validate(ctx context.Context, getSegment GetSegmentFunc) error {
+	if s.Meta == nil || len(s.Meta.LinkHash) == 0 {
+		return ErrMissingLinkHash
+	}
+
+	linkHash, err := s.Link.Hash()
+	if err != nil {
+		return err
+	}
+
+	if !bytes.Equal(linkHash, s.Meta.LinkHash) {
+		return ErrLinkHashMismatch
+	}
+
+	return s.Link.Validate(ctx, getSegment)
+}

--- a/segment_test.go
+++ b/segment_test.go
@@ -1,0 +1,80 @@
+// Copyright 2017-2018 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainscript_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stratumn/go-chainscript"
+	"github.com/stratumn/go-chainscript/chainscripttest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSegment_LinkHash(t *testing.T) {
+	l := chainscripttest.NewLinkBuilder(t).Build()
+	s := &chainscript.Segment{Link: l}
+
+	err := s.SetLinkHash()
+	require.NoError(t, err)
+
+	lh := s.GetLinkHashString()
+	assert.NotEmpty(t, lh)
+
+	err = s.SetLinkHash()
+	require.NoError(t, err)
+	lhh := s.GetLinkHashString()
+	assert.Equal(t, lh, lhh)
+}
+
+func TestSegment_Validate(t *testing.T) {
+	t.Run("missing link hash", func(t *testing.T) {
+		l := chainscripttest.NewLinkBuilder(t).Build()
+		s := &chainscript.Segment{Link: l}
+
+		err := s.Validate(context.Background(), nil)
+		assert.EqualError(t, err, chainscript.ErrMissingLinkHash.Error())
+	})
+
+	t.Run("link hash mismatch", func(t *testing.T) {
+		l := chainscripttest.NewLinkBuilder(t).Build()
+		s := &chainscript.Segment{
+			Link: l,
+			Meta: &chainscript.SegmentMeta{
+				LinkHash: []byte{42, 42, 42},
+			},
+		}
+
+		err := s.Validate(context.Background(), nil)
+		assert.EqualError(t, err, chainscript.ErrLinkHashMismatch.Error())
+	})
+
+	t.Run("invalid link", func(t *testing.T) {
+		s, err := chainscripttest.NewLinkBuilder(t).WithInvalidFields().Build().Segmentify()
+		require.NoError(t, err)
+
+		err = s.Validate(context.Background(), nil)
+		assert.Error(t, err)
+	})
+
+	t.Run("valid segment", func(t *testing.T) {
+		s, err := chainscripttest.NewLinkBuilder(t).Build().Segmentify()
+		require.NoError(t, err)
+
+		err = s.Validate(context.Background(), nil)
+		require.NoError(t, err)
+	})
+}

--- a/segment_test.go
+++ b/segment_test.go
@@ -31,12 +31,12 @@ func TestSegment_LinkHash(t *testing.T) {
 	err := s.SetLinkHash()
 	require.NoError(t, err)
 
-	lh := s.GetLinkHashString()
+	lh := s.LinkHashString()
 	assert.NotEmpty(t, lh)
 
 	err = s.SetLinkHash()
 	require.NoError(t, err)
-	lhh := s.GetLinkHashString()
+	lhh := s.LinkHashString()
 	assert.Equal(t, lh, lhh)
 }
 


### PR DESCRIPTION
- Import and rework the chainscript test builder
- Add set/get data/metadata methods to the link structure (provides versioning integration)
- Basic utility methods for segments

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/go-chainscript/6)
<!-- Reviewable:end -->
