### PR TITLE
evidence: proof interface and simple utilities

### DIFF
--- a/evidence.go
+++ b/evidence.go
@@ -1,0 +1,54 @@
+// Copyright 2017-2018 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainscript
+
+// NewEvidence creates a new evidence that can be added to a segment.
+func NewEvidence(version, backend, provider string, proofData []byte) (*Evidence, error) {
+	e := &Evidence{
+		Version:  version,
+		Backend:  backend,
+		Provider: provider,
+		Proof:    proofData,
+	}
+
+	err := e.Validate()
+	if err != nil {
+		return nil, err
+	}
+
+	return e, nil
+}
+
+// Validate that the evidence is well-formed.
+// The proof is opaque bytes so it isn't validated here.
+func (e *Evidence) Validate() error {
+	if len(e.Version) == 0 {
+		return ErrMissingVersion
+	}
+
+	if len(e.Backend) == 0 {
+		return ErrMissingBackend
+	}
+
+	if len(e.Provider) == 0 {
+		return ErrMissingProvider
+	}
+
+	if len(e.Proof) == 0 {
+		return ErrMissingProof
+	}
+
+	return nil
+}

--- a/evidence_test.go
+++ b/evidence_test.go
@@ -1,0 +1,86 @@
+// Copyright 2017-2018 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainscript_test
+
+import (
+	"testing"
+
+	"github.com/stratumn/go-chainscript"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEvidence_New(t *testing.T) {
+	testCases := []struct {
+		name     string
+		version  string
+		backend  string
+		provider string
+		proof    []byte
+		err      error
+	}{{
+		"missing version",
+		"",
+		"bitcoin",
+		"0x42",
+		[]byte{42},
+		chainscript.ErrMissingVersion,
+	}, {
+		"missing backend",
+		"0.1.0",
+		"",
+		"0x42",
+		[]byte{42},
+		chainscript.ErrMissingBackend,
+	}, {
+		"missing provider",
+		"0.1.1",
+		"bitcoin",
+		"",
+		[]byte{42},
+		chainscript.ErrMissingProvider,
+	}, {
+		"missing proof",
+		"0.1.1",
+		"bitcoin",
+		"0x42",
+		nil,
+		chainscript.ErrMissingProof,
+	}, {
+		"valid evidence",
+		"0.1.1",
+		"bitcoin",
+		"0x42",
+		[]byte{42},
+		nil,
+	}}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			e, err := chainscript.NewEvidence(tt.version, tt.backend, tt.provider, tt.proof)
+			if tt.err != nil {
+				assert.EqualError(t, err, tt.err.Error())
+			} else {
+				require.NoError(t, err)
+				assert.NotNil(t, e)
+				assert.Equal(t, tt.version, e.Version)
+				assert.Equal(t, tt.backend, e.Backend)
+				assert.Equal(t, tt.provider, e.Provider)
+				assert.Equal(t, tt.proof, e.Proof)
+				assert.NoError(t, e.Validate())
+			}
+		})
+	}
+}

--- a/link.go
+++ b/link.go
@@ -36,6 +36,7 @@ const (
 
 // Link errors.
 var (
+	ErrMissingVersion     = errors.New("version is missing")
 	ErrUnknownLinkVersion = errors.New("unknown link version")
 	ErrRefNotFound        = errors.New("referenced link could not be retrieved")
 )
@@ -178,6 +179,9 @@ func (l *Link) Clone() (*Link, error) {
 
 // Validate checks for errors in a link.
 func (l *Link) Validate(ctx context.Context, getSegment GetSegmentFunc) error {
+	if len(l.Version) == 0 {
+		return ErrMissingVersion
+	}
 	if l.Meta.Process == nil || len(l.Meta.Process.Name) == 0 {
 		return ErrMissingProcess
 	}

--- a/link_test.go
+++ b/link_test.go
@@ -169,6 +169,14 @@ func TestLink_Validate(t *testing.T) {
 		getSegment chainscript.GetSegmentFunc
 		err        error
 	}{{
+		"missing version",
+		func(*testing.T) *chainscript.Link {
+			l := chainscripttest.NewLinkBuilder(t).WithVersion("").Build()
+			return l
+		},
+		nil,
+		chainscript.ErrMissingVersion,
+	}, {
 		"missing process",
 		func(*testing.T) *chainscript.Link {
 			l := chainscripttest.NewLinkBuilder(t).WithProcess("").Build()

--- a/proof.go
+++ b/proof.go
@@ -1,0 +1,27 @@
+// Copyright 2017-2018 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainscript
+
+// Proof is the generic interface an evidence's proof should implement.
+type Proof interface {
+	// Time returns the timestamp (UNIX format) of the proof
+	Time() uint64
+
+	// Verify the validity of the proof.
+	// For most proof an input is required. For example, a proof containing a
+	// merkle path would require the link's hash to verify that it is correctly
+	// contained in the merkle path.
+	Verify(interface{}) bool
+}

--- a/segment.go
+++ b/segment.go
@@ -76,17 +76,9 @@ func (s *Segment) Validate(ctx context.Context, getSegment GetSegmentFunc) error
 
 // AddEvidence adds an evidence to the segment.
 func (s *Segment) AddEvidence(evidence *Evidence) error {
-	if len(evidence.Version) == 0 {
-		return ErrMissingVersion
-	}
-	if len(evidence.Backend) == 0 {
-		return ErrMissingBackend
-	}
-	if len(evidence.Provider) == 0 {
-		return ErrMissingProvider
-	}
-	if len(evidence.Proof) == 0 {
-		return ErrMissingProof
+	err := evidence.Validate()
+	if err != nil {
+		return err
 	}
 
 	if e := s.GetEvidence(evidence.Backend, evidence.Provider); e != nil {

--- a/segment_test.go
+++ b/segment_test.go
@@ -78,3 +78,113 @@ func TestSegment_Validate(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+func TestSegment_Evidence(t *testing.T) {
+	createBtcEvidence := func() *chainscript.Evidence {
+		return &chainscript.Evidence{
+			Version:  "1.0.0",
+			Backend:  "bitcoin",
+			Provider: "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
+			Proof:    []byte{42},
+		}
+	}
+
+	t.Run("add evidence", func(t *testing.T) {
+		t.Run("missing version", func(t *testing.T) {
+			s, _ := chainscripttest.NewLinkBuilder(t).Build().Segmentify()
+			e := createBtcEvidence()
+			e.Version = ""
+			err := s.AddEvidence(e)
+			assert.EqualError(t, err, chainscript.ErrMissingVersion.Error())
+		})
+
+		t.Run("missing backend", func(t *testing.T) {
+			s, _ := chainscripttest.NewLinkBuilder(t).Build().Segmentify()
+			e := createBtcEvidence()
+			e.Backend = ""
+			err := s.AddEvidence(e)
+			assert.EqualError(t, err, chainscript.ErrMissingBackend.Error())
+		})
+
+		t.Run("missing provider", func(t *testing.T) {
+			s, _ := chainscripttest.NewLinkBuilder(t).Build().Segmentify()
+			e := createBtcEvidence()
+			e.Provider = ""
+			err := s.AddEvidence(e)
+			assert.EqualError(t, err, chainscript.ErrMissingProvider.Error())
+		})
+
+		t.Run("missing proof", func(t *testing.T) {
+			s, _ := chainscripttest.NewLinkBuilder(t).Build().Segmentify()
+			e := createBtcEvidence()
+			e.Proof = nil
+			err := s.AddEvidence(e)
+			assert.EqualError(t, err, chainscript.ErrMissingProof.Error())
+		})
+
+		t.Run("valid evidence", func(t *testing.T) {
+			s, _ := chainscripttest.NewLinkBuilder(t).Build().Segmentify()
+			err := s.AddEvidence(createBtcEvidence())
+			require.NoError(t, err)
+		})
+
+		t.Run("add duplicate evidence", func(t *testing.T) {
+			s, _ := chainscripttest.NewLinkBuilder(t).Build().Segmentify()
+			e := createBtcEvidence()
+			s.AddEvidence(e)
+
+			e2 := createBtcEvidence()
+			e2.Proof = []byte{63}
+			err := s.AddEvidence(e2)
+			assert.EqualError(t, err, chainscript.ErrDuplicateEvidence.Error())
+
+			storedEvidence := s.GetEvidence(e.Backend, e.Provider)
+			require.NotNil(t, storedEvidence)
+			assert.Equal(t, e.Proof, storedEvidence.Proof)
+		})
+	})
+
+	t.Run("get evidence", func(t *testing.T) {
+		t.Run("valid evidence", func(t *testing.T) {
+			s, _ := chainscripttest.NewLinkBuilder(t).Build().Segmentify()
+			e := createBtcEvidence()
+			s.AddEvidence(e)
+
+			storedEvidence := s.GetEvidence(e.Backend, e.Provider)
+			assert.Equal(t, e, storedEvidence)
+		})
+
+		t.Run("no result", func(t *testing.T) {
+			s, _ := chainscripttest.NewLinkBuilder(t).Build().Segmentify()
+			e := s.GetEvidence("santa", "doesn't exist")
+			assert.Nil(t, e)
+		})
+	})
+
+	t.Run("find evidence", func(t *testing.T) {
+		t.Run("valid evidences", func(t *testing.T) {
+			mainnet := "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"
+			e1 := createBtcEvidence()
+			e1.Provider = mainnet
+
+			testnet := "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"
+			e2 := createBtcEvidence()
+			e2.Provider = testnet
+
+			s, _ := chainscripttest.NewLinkBuilder(t).Build().Segmentify()
+			s.AddEvidence(e1)
+			s.AddEvidence(e2)
+
+			e := s.FindEvidences(e1.Backend)
+			assert.ElementsMatch(t, []*chainscript.Evidence{e1, e2}, e)
+		})
+
+		t.Run("no result", func(t *testing.T) {
+			s, _ := chainscripttest.NewLinkBuilder(t).Build().Segmentify()
+			s.AddEvidence(createBtcEvidence())
+
+			e := s.FindEvidences("santa")
+			assert.Empty(t, e)
+		})
+	})
+}


### PR DESCRIPTION
Adding some utilities to deal with evidence.
I think we need to keep the evidence opaque to this package to allow users to add new evidences and make them evolve (ie change the evidence version if for example they change the format of their merkle path).
As Pierre pointed out previously, it will be worth defining the evidence types we use in our projects in the chainscript repo to make them easy to share between go and js. But no need to do that right now, we'll do it once go-chainscript and js-chainscript are ready(-ish).