### PR TITLE
signature: fix map id property name

### DIFF
--- a/signature_test.go
+++ b/signature_test.go
@@ -114,7 +114,7 @@ func TestLink_SignedBytes(t *testing.T) {
 		t.Run("partial meta", func(t *testing.T) {
 			l := chainscripttest.NewLinkBuilder(t).Build()
 
-			b1, err := l.SignedBytes(v1, "[meta.action,meta.process.name,meta.map_id]")
+			b1, err := l.SignedBytes(v1, "[meta.action,meta.process.name,meta.mapId]")
 			require.NoError(t, err)
 
 			b2, err := l.SignedBytes(v1, "[meta.action,meta.process.name]")
@@ -129,7 +129,7 @@ func TestLink_SignedBytes(t *testing.T) {
 				"random": 63,
 			}).Build()
 
-			path := "[data,meta.process.name,meta.map_id]"
+			path := "[data,meta.process.name,meta.mapId]"
 			b1, err := l1.SignedBytes(v1, path)
 			require.NoError(t, err)
 


### PR DESCRIPTION
Canonical JSON uses mapId instead of map_id.
This gave me a headache comparing the go and JS implementations :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/go-chainscript/10)
<!-- Reviewable:end -->
