### PR TITLE
signature: update go-crypto

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -63,7 +63,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:3aba9cbc7fe67f84dd354969ab5c6ff18992b5209410a643717939369542d59c"
+  digest = "1:ace6b21419576487bb35928611f66504a9494f2340420996a8935154cd0110dc"
   name = "github.com/stratumn/go-crypto"
   packages = [
     "encoding",
@@ -71,7 +71,7 @@
     "signatures",
   ]
   pruneopts = "UT"
-  revision = "e238d86e5d5a880603e2bfed02c0c9a90df12a6e"
+  revision = "51a04ed715ee95f4c6a9f639e6da8bd4cc4fd470"
 
 [[projects]]
   digest = "1:c40d65817cdd41fac9aa7af8bed56927bb2d6d47e4fea566a74880f5c2b1c41e"
@@ -103,6 +103,7 @@
     "github.com/golang/protobuf/proto",
     "github.com/jmespath/go-jmespath",
     "github.com/pkg/errors",
+    "github.com/stratumn/go-crypto/keys",
     "github.com/stratumn/go-crypto/signatures",
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/require",

--- a/signature.go
+++ b/signature.go
@@ -47,6 +47,10 @@ var (
 // with the given private key. If no payloadPath is provided, the whole link
 // is signed.
 func (l *Link) Sign(privateKey []byte, payloadPath string) error {
+	if len(payloadPath) == 0 {
+		payloadPath = "[version,data,meta]"
+	}
+
 	payload, err := l.SignedBytes(SignatureVersion, payloadPath)
 	if err != nil {
 		return err
@@ -59,7 +63,6 @@ func (l *Link) Sign(privateKey []byte, payloadPath string) error {
 
 	s := &Signature{
 		Version:     SignatureVersion,
-		Type:        sig.AI,
 		PayloadPath: payloadPath,
 		PublicKey:   sig.PublicKey,
 		Signature:   sig.Signature,
@@ -109,7 +112,6 @@ func (s *Signature) Validate(l *Link) error {
 	switch s.Version {
 	case SignatureVersion1_0_0:
 		sig := signatures.Signature{
-			AI:        s.Type,
 			Message:   signedBytes,
 			PublicKey: s.PublicKey,
 			Signature: s.Signature,


### PR DESCRIPTION
Update go-crypto to work with js-chainscript's signatures.
Fix empty payload path (it's better to be explicit about the fact that we sign the whole link).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/go-chainscript/13)
<!-- Reviewable:end -->
