### PR TITLE
cmd: set exit code for unknown test case

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -101,6 +101,7 @@ func validate(path string) {
 		tt, ok := TestCases[t.ID]
 		if !ok {
 			fmt.Printf("Unkown test case: %s\n", t.ID)
+			failed = true
 			continue
 		}
 


### PR DESCRIPTION
An unknown test case should be treated as a failure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/go-chainscript/17)
<!-- Reviewable:end -->
