### PR TITLE
chainscripttest: RandomHash returns a chainscript.LinkHash

### DIFF
--- a/chainscripttest/random.go
+++ b/chainscripttest/random.go
@@ -33,7 +33,7 @@ func RandomBytes(n int) []byte {
 }
 
 // RandomHash creates a random hash.
-func RandomHash() []byte {
+func RandomHash() chainscript.LinkHash {
 	return RandomBytes(32)
 }
 


### PR DESCRIPTION
It makes the String() method available out of the box without the need for an explicit cast.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/go-chainscript/22)
<!-- Reviewable:end -->
