### PR TITLE
evidence: add marshalling helpers

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -50,3 +50,19 @@ func UnmarshalLink(b []byte) (*Link, error) {
 
 	return &unmarshalled, nil
 }
+
+// MarshalEvidence marshals using protobuf.
+func MarshalEvidence(e *Evidence) ([]byte, error) {
+	return proto.Marshal(e)
+}
+
+// UnmarshalEvidence unmarshals protobuf bytes.
+func UnmarshalEvidence(b []byte) (*Evidence, error) {
+	var unmarshalled Evidence
+	err := proto.Unmarshal(b, &unmarshalled)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return &unmarshalled, nil
+}


### PR DESCRIPTION
It makes it obvious to the client how to marshal/unmarshal without having to import golang/protobuf

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/go-chainscript/23)
<!-- Reviewable:end -->
