### PR TITLE
chainscripttest: remove random prevLinkHash.

### DIFF
--- a/chainscripttest/builder.go
+++ b/chainscripttest/builder.go
@@ -163,7 +163,6 @@ func (lb *LinkBuilder) WithRandomData() *LinkBuilder {
 	lb.Link.Meta.Action = RandomString(12)
 	lb.Link.Meta.Data = RandomBytes(24)
 	lb.Link.Meta.MapId = RandomString(24)
-	lb.Link.Meta.PrevLinkHash = RandomHash()
 	lb.Link.Meta.Priority = rand.Float64()
 	lb.Link.Meta.Process = &chainscript.Process{
 		Name:  RandomString(24),


### PR DESCRIPTION
It would make too much normal validation rules fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/go-chainscript/27)
<!-- Reviewable:end -->
